### PR TITLE
Dependencies: remove kotlin-compiler

### DIFF
--- a/arrow-ank/build.gradle
+++ b/arrow-ank/build.gradle
@@ -14,9 +14,6 @@ apply from: "$PUBLISH_CONF"
 dependencies {
     compile "io.arrow-kt:arrow-fx:$VERSION_NAME"
 
-    runtime "org.jetbrains.kotlin:kotlin-compiler:$KOTLIN_VERSION"
-    runtime "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:$KOTLIN_VERSION"
-    compile "org.jetbrains.kotlin:kotlin-compiler-embeddable:$KOTLIN_VERSION"
     compile "org.jetbrains.kotlin:kotlin-script-util:$KOTLIN_VERSION"
     runtime "org.jetbrains.kotlin:kotlin-reflect:$KOTLIN_VERSION"
     kapt "io.arrow-kt:arrow-meta:$VERSION_NAME"


### PR DESCRIPTION
To fix 'org.jetbrains.kotlin.idea.KotlinFileType cannot be cast to org.jetbrains.kotlin.com.intellij.openapi.fileTypes.LanguageFileType' error which happens because of having kotlin-compiler and kotlin-compiler-embeddable at the same time.