### PR TITLE
Fix dependencies

### DIFF
--- a/arrow-ank-gradle/src/main/kotlin/arrow/ank/AnkPlugin.kt
+++ b/arrow-ank-gradle/src/main/kotlin/arrow/ank/AnkPlugin.kt
@@ -19,8 +19,6 @@ class AnkPlugin : Plugin<Project> {
     val extension = AnkExtension()
     target.extensions.add(EXTENSION_NAME, extension)
     target.afterEvaluate {
-      target.dependencies.add("runtimeOnly", "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:${properties.getProperty("KOTLIN_VERSION")}")
-      target.dependencies.add("runtimeOnly", "org.jetbrains.kotlin:kotlin-compiler-embeddable:${properties.getProperty("KOTLIN_VERSION")}")
       target.dependencies.add("runtimeOnly", "io.arrow-kt:arrow-ank:${properties.getProperty("CURRENT_VERSION")}")
       target.tasks.create(TASK_NAME, JavaExec::class.java).apply {
         classpath = extension.classpath

--- a/arrow-ank/build.gradle
+++ b/arrow-ank/build.gradle
@@ -14,6 +14,9 @@ apply from: "$PUBLISH_CONF"
 dependencies {
     compile "io.arrow-kt:arrow-fx:$VERSION_NAME"
 
+    runtime "org.jetbrains.kotlin:kotlin-compiler:$KOTLIN_VERSION"
+    runtime "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:$KOTLIN_VERSION"
+    compile "org.jetbrains.kotlin:kotlin-compiler-embeddable:$KOTLIN_VERSION"
     compile "org.jetbrains.kotlin:kotlin-script-util:$KOTLIN_VERSION"
     runtime "org.jetbrains.kotlin:kotlin-reflect:$KOTLIN_VERSION"
     kapt "io.arrow-kt:arrow-meta:$VERSION_NAME"

--- a/arrow-ank/build.gradle
+++ b/arrow-ank/build.gradle
@@ -14,10 +14,10 @@ apply from: "$PUBLISH_CONF"
 dependencies {
     compile "io.arrow-kt:arrow-fx:$VERSION_NAME"
 
-    runtime "org.jetbrains.kotlin:kotlin-compiler:$KOTLIN_VERSION"
-    runtime "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:$KOTLIN_VERSION"
-    compile "org.jetbrains.kotlin:kotlin-compiler-embeddable:$KOTLIN_VERSION"
+    compile "org.jetbrains.kotlin:kotlin-compiler:$KOTLIN_VERSION"
     compile "org.jetbrains.kotlin:kotlin-script-util:$KOTLIN_VERSION"
-    runtime "org.jetbrains.kotlin:kotlin-reflect:$KOTLIN_VERSION"
+    runtimeOnly "org.jetbrains.kotlin:kotlin-reflect:$KOTLIN_VERSION"
+    runtimeOnly "org.jetbrains.kotlin:kotlin-compiler:$KOTLIN_VERSION"
+    runtimeOnly "org.jetbrains.kotlin:kotlin-scripting-compiler:$KOTLIN_VERSION"
     kapt "io.arrow-kt:arrow-meta:$VERSION_NAME"
 }


### PR DESCRIPTION
Revert 65e1a819f0f41057dccbbcf7cf88ea6109ee34ae to fix `org.jetbrains.kotlin.idea.KotlinFileType cannot be cast to org.jetbrains.kotlin.com.intellij.openapi.fileTypes.LanguageFileType` error. 

That error happens when using `kotlin-compiler` and `kotlin-compiler-embeddable` at the same time. 

However, if `kotlin-compiler` is removed, running Ank raises `java.lang.NoClassDefFoundError: com/sun/jna/Native`. 

This change recovers the use of `kotlin-compiler`  and adds runtime dependencies from `build.gradle` instead of code.