### PR TITLE
Change configuration name to be included in pom file

### DIFF
--- a/arrow-ank/build.gradle
+++ b/arrow-ank/build.gradle
@@ -16,8 +16,7 @@ dependencies {
 
     compile "org.jetbrains.kotlin:kotlin-compiler:$KOTLIN_VERSION"
     compile "org.jetbrains.kotlin:kotlin-script-util:$KOTLIN_VERSION"
-    runtimeOnly "org.jetbrains.kotlin:kotlin-reflect:$KOTLIN_VERSION"
-    runtimeOnly "org.jetbrains.kotlin:kotlin-compiler:$KOTLIN_VERSION"
-    runtimeOnly "org.jetbrains.kotlin:kotlin-scripting-compiler:$KOTLIN_VERSION"
+    runtime "org.jetbrains.kotlin:kotlin-reflect:$KOTLIN_VERSION"
+    runtime "org.jetbrains.kotlin:kotlin-scripting-compiler:$KOTLIN_VERSION"
     kapt "io.arrow-kt:arrow-meta:$VERSION_NAME"
 }


### PR DESCRIPTION
I've just discovered that `runtimeOnly` dependencies are included in local POM file. However, they aren't included in OSS POM file.

It doesn't happen with `runtime` dependencies.

That's the reason why checks using local dependencies pass whereas the use of OSS dependencies for Ank fails.