### PR TITLE
Upgrade to Arrow Fx Coroutines

### DIFF
--- a/arrow-ank/build.gradle
+++ b/arrow-ank/build.gradle
@@ -11,7 +11,7 @@ apply from: "$DOC_CONF"
 apply from: "$PUBLISH_CONF"
 
 dependencies {
-    compile "io.arrow-kt:arrow-fx:$VERSION_NAME"
+    compile "io.arrow-kt:arrow-fx-coroutines:$VERSION_NAME"
 
     compile "org.jetbrains.kotlin:kotlin-compiler:$KOTLIN_VERSION"
     compile "org.jetbrains.kotlin:kotlin-script-util:$KOTLIN_VERSION"

--- a/arrow-ank/src/main/kotlin/arrow/ank/ank.kt
+++ b/arrow-ank/src/main/kotlin/arrow/ank/ank.kt
@@ -19,9 +19,6 @@ fun Long.humanBytes(): String {
   return String.format("%.1f %sB", this / unit.toDouble().pow(exp.toDouble()), pre)
 }
 
-fun <A> toValidatedNel(a: Either<Throwable, A>): ValidatedNel<Throwable, A> =
-  a.fold({ e -> Validated.Invalid(NonEmptyList(e)) }, { a -> Validated.Valid(a) })
-
 suspend fun ank(source: Path, target: Path, compilerArgs: List<String>, ankOps: AnkOps): Unit = with(ankOps) {
   printConsole(colored(ANSI_PURPLE, AnkHeader))
   val heapSize = Runtime.getRuntime().totalMemory()

--- a/arrow-ank/src/main/kotlin/arrow/ank/ank.kt
+++ b/arrow-ank/src/main/kotlin/arrow/ank/ank.kt
@@ -1,9 +1,14 @@
 package arrow.ank
 
-import arrow.core.*
+import arrow.core.Either
+import arrow.core.NonEmptyList
+import arrow.core.ValidatedNel
 import arrow.core.extensions.list.traverse.sequence
 import arrow.core.extensions.nonemptylist.semigroup.semigroup
 import arrow.core.extensions.validated.applicative.applicative
+import arrow.core.fix
+import arrow.core.nel
+import arrow.core.toT
 import java.nio.file.Path
 import kotlin.math.ln
 import kotlin.math.pow

--- a/arrow-ank/src/main/kotlin/arrow/ank/ank.kt
+++ b/arrow-ank/src/main/kotlin/arrow/ank/ank.kt
@@ -6,8 +6,6 @@ import arrow.core.extensions.list.traverse.sequence
 import arrow.core.extensions.nonemptylist.semigroup.semigroup
 import arrow.core.extensions.validated.applicative.applicative
 import arrow.core.fix
-import arrow.core.nel
-import arrow.core.toT
 import arrow.core.invalidNel
 import arrow.core.toT
 import arrow.core.validNel

--- a/arrow-ank/src/main/kotlin/arrow/ank/ank.kt
+++ b/arrow-ank/src/main/kotlin/arrow/ank/ank.kt
@@ -1,20 +1,10 @@
 package arrow.ank
 
-import arrow.Kind
-import arrow.core.Either
-import arrow.core.ListK
-import arrow.core.Nel
-import arrow.core.NonEmptyList
-import arrow.core.Validated
-import arrow.core.ValidatedNel
-import arrow.core.combine
-import arrow.core.extensions.list.foldable.reduceLeftOption
-import arrow.core.extensions.list.semigroup.List.semigroup
+import arrow.core.*
+import arrow.core.extensions.list.traverse.sequence
 import arrow.core.extensions.nonemptylist.semigroup.semigroup
-import arrow.core.getOrElse
-import arrow.core.toT
-import arrow.core.validNel
-import arrow.fx.typeclasses.Concurrent
+import arrow.core.extensions.validated.applicative.applicative
+import arrow.fx.coroutines.parTraverse
 import java.nio.file.Path
 import kotlin.math.ln
 import kotlin.math.pow
@@ -30,59 +20,43 @@ fun Long.humanBytes(): String {
   return String.format("%.1f %sB", this / unit.toDouble().pow(exp.toDouble()), pre)
 }
 
-fun <A> toValidatedNel(a: Either<Throwable, A>): ValidatedNel<Throwable, A> =
-  a.fold({ e -> Validated.Invalid(NonEmptyList(e)) }, { a -> Validated.Valid(a) })
+suspend fun ank(source: Path, target: Path, compilerArgs: List<String>, ankOps: AnkOps): Unit = with(ankOps) {
+  printConsole(colored(ANSI_PURPLE, AnkHeader))
+  val heapSize = Runtime.getRuntime().totalMemory()
+  val heapMaxSize = Runtime.getRuntime().maxMemory()
+  printConsole("Current heap used: ${(heapSize - Runtime.getRuntime().freeMemory()).humanBytes()}")
+  printConsole("Starting ank with Heap Size: ${heapSize.humanBytes()}, Max Heap Size: ${heapMaxSize.humanBytes()}")
+  val path = createTargetDirectory(source, target)
 
-fun <F> Concurrent<F>.ank(source: Path, target: Path, compilerArgs: List<String>, ankOps: AnkOps): Kind<F, Unit> = with(ankOps) {
-  fx.concurrent {
-    !effect { printConsole(colored(ANSI_PURPLE, AnkHeader)) }
-    val heapSize = Runtime.getRuntime().totalMemory()
-    val heapMaxSize = Runtime.getRuntime().maxMemory()
-    !effect { printConsole("Current heap used: ${(heapSize - Runtime.getRuntime().freeMemory()).humanBytes()}") }
-    !effect { printConsole("Starting ank with Heap Size: ${heapSize.humanBytes()}, Max Heap Size: ${heapMaxSize.humanBytes()}") }
-    val path = !effect { createTargetDirectory(source, target) }
-    val validatedPaths = !effect {
-      path.ankFiles().map { (index, p) ->
-        effect {
-          val totalHeap = Runtime.getRuntime().totalMemory()
-          val usedHeap = totalHeap - Runtime.getRuntime().freeMemory()
-          val message = "Ank Compile: [$index] ${path.relativize(p)} | Used Heap: ${usedHeap.humanBytes()}"
-          printConsole(colored(ANSI_GREEN, message))
-          val preProcessed = p.processMacros()
-          val (processed, snippets) = extractCode(preProcessed)
-          val compiledResult = compileCode(p toT snippets, compilerArgs)
-          val result = replaceAnkToLang(processed, compiledResult)
-          generateFile(p, result)
-        }.attempt().map(::toValidatedNel)
-      }.toList()
+  val validatedPaths = path.ankFiles().toList().parTraverse {
+    try {
+      val totalHeap = Runtime.getRuntime().totalMemory()
+      val usedHeap = totalHeap - Runtime.getRuntime().freeMemory()
+      val p = it.path
+      val message = "Ank Compile: [${it.index}] ${path.relativize(p)} | Used Heap: ${usedHeap.humanBytes()}"
+      printConsole(colored(ANSI_GREEN, message))
+      val preProcessed = p.processMacros()
+      val (processed, snippets) = extractCode(preProcessed)
+      val compiledResult = compileCode(p toT snippets, compilerArgs)
+      val result = replaceAnkToLang(processed, compiledResult)
+      val generatedPath = generateFile(p, result)
+      generatedPath.validNel()
+    } catch (e: Throwable) {
+      e.invalidNel()
     }
+  }.sequence(Validated.applicative(NonEmptyList.semigroup())).fix()
 
-    // We need to help compiler here a bit.
-    val empty: Kind<F, ValidatedNel<Nothing, List<Path>>> = just(emptyList<Path>().validNel())
-
-    val combinedResults = !!effect {
-      validatedPaths
-        .map { fa -> fa.map { validated -> validated.map { path -> ListK.just(path) } } } // wrap in ListK to accumulate Paths.
-        .reduceLeftOption { fa, fb ->
-          fa.map2(fb) { (a: Validated<Nel<Throwable>, ListK<Path>>, b: Validated<Nel<Throwable>, ListK<Path>>) ->
-            a.combine(Nel.semigroup(), semigroup(), b)
-          }
-        }.getOrElse { empty }
-    }
-
-    !combinedResults.fold({ errors ->
-      val seperator = "\n----------------------------------------------------------------\n"
-      throw AnkFailedException(errors.all
-        .flatMap {
-          if (it is CompilationException) listOf(it)
-          else emptyList()
-        }.joinToString(prefix = seperator, separator = seperator) {
-          it.msg
-        }
-      )
-    }, { paths ->
-      val message = colored(ANSI_GREEN, "Ank Processed ${paths.size} files")
-      effect { printConsole(message) }
-    })
-  }
+  validatedPaths.fold({ errors ->
+    val separator = "\n----------------------------------------------------------------\n"
+    throw AnkFailedException(errors.all
+      .flatMap {
+        if (it is CompilationException) listOf(it)
+        else emptyList()
+      }.joinToString(prefix = separator, separator = separator) {
+        it.msg
+      })
+  }, { paths ->
+    val message = colored(ANSI_GREEN, "Ank Processed ${paths.fix().size} files")
+    printConsole(message)
+  })
 }

--- a/arrow-ank/src/main/kotlin/arrow/ank/interpreter.kt
+++ b/arrow-ank/src/main/kotlin/arrow/ank/interpreter.kt
@@ -8,6 +8,8 @@ import arrow.core.Tuple3
 import arrow.core.extensions.sequence.foldable.foldLeft
 import arrow.core.some
 import arrow.core.toT
+import arrow.fx.coroutines.IOPool
+import arrow.fx.coroutines.evalOn
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.net.URL
@@ -93,7 +95,7 @@ val interpreter: AnkOps = object : AnkOps {
     }
 
   override suspend fun Path.ankFiles(): Sequence<AnkProcessingContext> =
-    Files.walk(this)
+    evalOn(IOPool) { Files.walk(this) }
       .filter { Files.isDirectory(it).not() }
       .filter { path ->
         SupportedMarkdownExtensions.fold(false) { c, ext ->

--- a/arrow-ank/src/main/kotlin/arrow/ank/main.kt
+++ b/arrow-ank/src/main/kotlin/arrow/ank/main.kt
@@ -2,26 +2,18 @@
 
 package arrow.ank
 
-import arrow.fx.IO
-import arrow.fx.extensions.io.concurrent.concurrent
-import arrow.fx.extensions.io.unsafeRun.runBlocking
-import arrow.unsafe
 import java.nio.file.Paths
 
-fun main(vararg args: String) {
-  unsafe {
-    runBlocking {
-      when {
-        args.size > 1 -> {
-          IO.concurrent().ank(
-            Paths.get(args[0]),
-            Paths.get(args[1]),
-            args.drop(2),
-            interpreter
-          )
-        }
-        else -> throw IllegalArgumentException("Required first 2 args as directory paths in this order: <required: source> <required: destination> <optional: classpath entries, one per arg..>")
-      }
+suspend fun main(vararg args: String) {
+  when {
+    args.size > 1 -> {
+      ank(
+        Paths.get(args[0]),
+        Paths.get(args[1]),
+        args.drop(2),
+        interpreter
+      )
     }
+    else -> throw IllegalArgumentException("Required first 2 args as directory paths in this order: <required: source> <required: destination> <optional: classpath entries, one per arg..>")
   }
 }

--- a/arrow-ank/src/main/kotlin/arrow/ank/main.kt
+++ b/arrow-ank/src/main/kotlin/arrow/ank/main.kt
@@ -4,7 +4,7 @@ package arrow.ank
 
 import java.nio.file.Paths
 
-suspend fun main(vararg args: String) {
+suspend fun main(vararg args: String) =
   when {
     args.size > 1 -> {
       ank(
@@ -16,4 +16,3 @@ suspend fun main(vararg args: String) {
     }
     else -> throw IllegalArgumentException("Required first 2 args as directory paths in this order: <required: source> <required: destination> <optional: classpath entries, one per arg..>")
   }
-}


### PR DESCRIPTION
Since 0.11.0-SNAPSHOT we want Ank to target Arrow Fx Coroutines instead of the old wrapped concurrent / IO style.